### PR TITLE
Fix package

### DIFF
--- a/pomidor.el
+++ b/pomidor.el
@@ -4,7 +4,7 @@
 ;; URL: https://github.com/TatriX/pomidor
 ;; Keywords: tools, time, productivity, pomodoro technique
 ;; Version: 0.1
-;; Package-Requires: ((emacs "24"))
+;; Package-Requires: ((emacs "24.3"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl-lib)
 
 
 ;;; Customs


### PR DESCRIPTION
- Correct minimum Emacs version.
  read-only-mode was introduced at Emacs 24.3

- Load cl-lib instead of cl for using cl-lib macros