### PR TITLE
fix invalid time specification

### DIFF
--- a/pomidor.el
+++ b/pomidor.el
@@ -257,7 +257,7 @@ TIME may be nil."
    (pomidor--format-time-string work 'pomidor-work-face)
    (let ((skip (- pomidor-seconds (time-to-seconds work))))
      (when (> skip 0)
-       (pomidor--format-time-string skip 'pomidor-skip-face)))
+       (pomidor--format-time-string (seconds-to-time skip) 'pomidor-skip-face)))
    (and overwork (pomidor--format-time-string overwork 'pomidor-overwork-face))
    (and break (pomidor--format-time-string break 'pomidor-break-face))))
 


### PR DESCRIPTION
Hi.
I have same problem - https://github.com/TatriX/pomidor/issues/1
This fix works for me. I'm using emacs 24.5.1 on ubuntu 16