### PR TITLE
fix stats alignment on tab-width less than 8

### DIFF
--- a/pomidor.el
+++ b/pomidor.el
@@ -411,6 +411,7 @@ TIME may be nil."
 
 \\{pomidor-mode-map}"
   (setq pomidor-timer (run-at-time nil 1 #'pomidor--update))
+  (setq-local tab-width 8)
   (add-hook 'kill-buffer-hook #'pomidor--cancel-timer nil t)
   (pomidor--reset))
 


### PR DESCRIPTION

![2017-08-18 03-46-38](https://user-images.githubusercontent.com/7482261/29439446-4b69d84e-83c6-11e7-8c88-9540398b4721.png)
Using of tab-width less than 8 was breaking stats alignment, so
now it explicitly set to 8 for pomidor-mode