### PR TITLE
Fixed the timer not rendering when frame is not in focus.

### DIFF
--- a/pomidor.el
+++ b/pomidor.el
@@ -285,7 +285,7 @@ TIME may be nil."
 (defun pomidor--render ()
   "Render pomidor state."
   (let ((buffer (pomidor--get-buffer-create)))
-    (when (get-buffer-window buffer)
+    (when (get-buffer-window buffer t)
       (with-current-buffer buffer
         (read-only-mode -1)
         (erase-buffer)


### PR DESCRIPTION
Fix for issue https://github.com/TatriX/pomidor/issues/4

In this fix: I've set the ALL-FRAMES optional argument to t so that the timer would render even if the frame the buffer is on is not in focus.