### PR TITLE
Fixing function that notifies when break ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For example to be notified of break end:
 (defun my-pomidor-update-hook ()
   (let ((break-duration 2) ;; seconds
         (ellapsed (time-to-seconds (pomidor-break-duration))))
-    (when (> ellapsed break-duration)
+    (when (and (> ellapsed break-duration) (pomidor--break (pomidor--current-state)))
       (pomidor-play-sound-file-async pomidor-sound-overwork))))
 
 (add-hook 'pomidor-update-hook #'my-pomidor-update-hook)


### PR DESCRIPTION
When the algorithm hasn't started the break, the current status is something like `(:started (23119 32850 428356 983000) :break nil :stopped nil)`. The function that returns the break duration is shown bellow:
```elisp
(defun pomidor--break-duration (state)
  "Return break time for STATE."
  (let ((break (pomidor--break state)))
    (and break (time-subtract (pomidor--ended state) break))))
```
When `:break` is nil, the function always returns a big number, since the operation `(time-subtract (pomidor--ended state) break))` it is evaluated to `(time-subtract current-time nil))`. A possible solution is to force the notify function to verify if `:break` is `nil`:
```elisp
 ;; notify me after my 5 minutes break 
(defun my-pomidor-update-hook ()
  (let ((break-duration (* 60 5)) ;; seconds
        (ellapsed (time-to-seconds (pomidor-break-duration))))
    (when (and (> ellapsed break-duration) (pomidor--break (pomidor--current-state)))
      (pomidor-play-sound-file-async pomidor-sound-overwork))))
```
However, a more permanent solution would be changing `pomidor-break-duration` to return `0` or `nil` when `:break` is `nil`.
  