### PR TITLE
Derive pomidor from special-mode

### DIFF
--- a/pomidor.el
+++ b/pomidor.el
@@ -456,7 +456,7 @@ TIME may be nil."
     (plist-put state :stopped (current-time)))
   (nconc pomidor-global-state (list (pomidor--make-state))))
 
-(define-derived-mode pomidor-mode fundamental-mode "pomidor"
+(define-derived-mode pomidor-mode special-mode "pomidor"
   "Major mode for Pomidor.
 
 \\{pomidor-mode-map}"


### PR DESCRIPTION
I think `pomidor-mode` should inherit from `special-mode`.

From the [info manual][0]:

> The recommended way to define a new major mode is to derive it from an existing one 
> using define-derived-mode. If there is no closely related mode, you should inherit from
> either `text-mode`, `special-mode`, or `prog-mode`. See [Basic Major Modes][1]. If none of
> these are suitable, you can inherit from `fundamental-mode` (see [Major Modes][2]). 

`special-mode` doesn't add much behavior-wise; it's mostly just about convention. E.g., some tools enable/disable certain keybindings or hooks in special mode. My motivation for this PR is to have [`god-mode`][3] automatically disable itself in the `*pomidor*` buffer without having to special-case it. (`god-mode` disables itself in modes derived from `special-mode` automatically)

It also provides a central point (`special-mode-map`) for users to define their own keybindings for modes that aren't about editing text. (E.g., I use `,` in special modes to change buffers)

There are a couple of other benefits which you can read about [here][4] if interested. (Search for "special")

[0]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Derived-Modes.html
[1]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Basic-Major-Modes.html#Basic-Major-Modes
[2]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Major-Modes.html#Major-Modes
[3]: https://github.com/chrisdone/god-mode
[4]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Major-Mode-Conventions.html#Major-Mode-Conventions