### PR TITLE
Implements pomidor-history-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## v.04 23/04/2020
+Add `pomidor-history-mode` to keep track of saved pomidor sessions.
+
 ## v0.2 12/03/2018
 Add break duration config and notification. See `pomidor-break-seconds`.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ After that you can fire `M-x pomidor-history` to take a look at your
 snapshots. You can press `n` (`pomidor-history-next`) or `p`
 (`pomidor-history-previous`) to navigate between the snapshots.
 
+Check a demo of this feature at [here](https://youtu.be/BJTT7nILcsY).
+
 ## Keybindings
 
 | Key   | Description          |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ it will ask to close your pomidor and will save the current state to a
 file defined by `pomidor-save-session-file` defaults to
 `~/.emacs.d/pomidor-sessions.el`.
 
+The name of each session stored is the timestamp of the time you
+choose to save the session.
+
 After that you can fire `M-x pomidor-history` to take a look at your
 snapshots. You can press `n` (`pomidor-history-next`) or `p`
 (`pomidor-history-previous`) to navigate between the snapshots.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ should finish your break. To snooze it just press `Space` and select
 
 This cycle goes on forever.
 
+## History mode
+
+You can save your pomodoro sessions in a file and compare your
+progress through this methodology as time goes by.
+
+When you desire to save a session just do `M-x pomidor-save-session`,
+it will ask to close your pomidor and will save the current state to a
+file defined by `pomidor-save-session-file` defaults to
+`~/.emacs.d/pomidor-sessions.el`.
+
+After that you can fire `M-x pomidor-history` to take a look at your
+snapshots. You can press `n` (`pomidor-history-next`) or `p`
+(`pomidor-history-previous`) to navigate between the snapshots.
+
 ## Keybindings
 
 | Key   | Description          |

--- a/pomidor.el
+++ b/pomidor.el
@@ -557,8 +557,11 @@ TIME may be nil."
                                                session-dates)
                                     session-dates))
              (previous-session (car (last valid-session-dates))))
-        (setq pomidor--current-history-session previous-session)
-        (pomidor--render (pomidor--get-history-buffer-create) (gethash previous-session session-table))))))
+        (if previous-session
+            (progn
+              (setq pomidor--current-history-session previous-session)
+              (pomidor--render (pomidor--get-history-buffer-create) (gethash previous-session session-table)))
+          (message "History is over, go forward."))))))
 
 (defun pomidor-history-next ()
   "Move forward in your pomidor history."
@@ -573,8 +576,11 @@ TIME may be nil."
                                                session-dates)
                                     session-dates))
              (next-session (car valid-session-dates)))
-        (setq pomidor--current-history-session next-session)
-        (pomidor--render (pomidor--get-history-buffer-create) (gethash next-session session-table))))))
+        (if next-session
+            (progn
+              (setq pomidor--current-history-session next-session)
+              (pomidor--render (pomidor--get-history-buffer-create) (gethash next-session session-table)))
+          (message "History is over, go backward."))))))
 
 
 (defun pomidor-history ()

--- a/pomidor.el
+++ b/pomidor.el
@@ -590,17 +590,21 @@ TIME may be nil."
       (message "You should save at least one session first.")
     (switch-to-buffer (pomidor--get-history-buffer-create))
     (pomidor-history-previous)
-    (pomidor-history-mode)))
+    (unless (eq major-mode 'pomidor-history-mode)
+      (pomidor-history-mode))))
 
-;;;###autoload
-(define-minor-mode pomidor-history-mode
-  "Minor mode for Pomidor History."
-  :lighter "pomidor-history"
-  :keymap (let ((map (make-sparse-keymap)))
-            (define-key map (kbd "q") #'quit-window)
-            (define-key map (kbd "n") #'pomidor-history-next)
-            (define-key map (kbd "p") #'pomidor-history-previous)
-            map)
+(defvar pomidor-history-mode-map
+  (let ((map (make-keymap)))
+    (define-key map (kbd "q") #'quit-window)
+    (define-key map (kbd "n") #'pomidor-history-next)
+    (define-key map (kbd "p") #'pomidor-history-previous)
+    (suppress-keymap map)
+    map))
+
+(define-derived-mode pomidor-history-mode special-mode "pomidor-history"
+  "Major mode for Pomidor History.
+
+\\{pomidor-history-mode-map}"
   (setq pomidor-timer nil)
   (setq pomidor--current-history-session nil))
 

--- a/pomidor.el
+++ b/pomidor.el
@@ -90,7 +90,7 @@
   :type '(file :must-match t)
   :group 'pomidor)
 
-(defcustom pomidor-save-session-file (expand-file-name user-emacs-directory "pomidor-session.el")
+(defcustom pomidor-save-session-file (expand-file-name "pomidor-session.el" user-emacs-directory)
   "Pomidor session store file."
   :type '(file :must-match t)
   :group 'pomidor)


### PR DESCRIPTION
Hello @TatriX , thanks for the package, very nicely done.

I was looking for a pomodor package to help me store historic snapshots of my pomodoro sessions. I would like to compare between these snapshots day after day to see progression in the metodology.

I was not able to find one, but I really liked the way  `pomidor` works, so I decided to implement the feature I wanted. This PR contains some code to define a `pomidor-history-mode`:

You can save your pomodoro sessions in a file and compare your progress through this methodology as time goes by.

When you desire to save a session just do `M-x pomidor-save-session`, it will ask to close your pomidor and will save the current state to a file defined by `pomidor-save-session-file` defaults to
`~/.emacs.d/pomidor-sessions.el`.

The name of each session stored is the timestamp of the time you choose to save the session.

After that you can fire `M-x pomidor-history` to take a look at your snapshots. You can press `n` (`pomidor-history-next`) or `p` (`pomidor-history-previous`) to navigate between the snapshots.

A small video demonstrating the functionality:  https://youtu.be/BJTT7nILcsY

As I think this feature does not cause any harm with the core package, I think would be nice to other people with similar interest.

I still plan to do some basic statistics accross the snapshots like average and total over week(s) and month (s).

Would like to hear what you think about this and any feedback is greatly welcome.
Thanks in advance!!