### PR TITLE
add feature to hold a pomidor session after started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.05 04/05/2020
+Add `pomidor-hold` and `pomidor-unhold` functions to keep a period of
+time without working on your pomidor sessions and resume when needed.
+
 ## v.04 23/04/2020
 Add `pomidor-history-mode` to keep track of saved pomidor sessions.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ should finish your break. To snooze it just press `Space` and select
 
 This cycle goes on forever.
 
+However, there are situations when you really cannot work in your next
+pomidor session for a time hiatus, and you also do not want to lose
+the track of what you already did.
+
+You can use `pomidor-hold` to put your current session on hold and
+when you want to get back to pomidor-land you use `pomidor-unhold`.
+The unhold function will create a new pomidor session and you can
+continue the virtuous cycle.
+
+
 ## History mode
 
 You can save your pomodoro sessions in a file and compare your

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ However, there are situations when you really cannot work in your next
 pomidor session for a time hiatus, and you also do not want to lose
 the track of what you already did.
 
-You can use `pomidor-hold` to put your current session on hold and
-when you want to get back to pomidor-land you use `pomidor-unhold`.
-The unhold function will create a new pomidor session and you can
-continue the virtuous cycle.
+You can use `h` (`pomidor-hold`) to put your current session on hold
+and when you want to get back to pomidor-land you use `H`
+(`pomidor-unhold`). The unhold function will create a new pomidor
+session and you can continue the virtuous cycle.
 
 
 ## History mode
@@ -91,13 +91,16 @@ Check a demo of this feature at [here](https://youtu.be/BJTT7nILcsY).
 
 ## Keybindings
 
-| Key   | Description          |
-|-------|----------------------|
-| Enter | Start new pomodoro.  |
-| Space | Start a break.       |
-| R     | Resets the timer.    |
-| q     | Quit pomidor buffer. |
-| Q     | Turns off pomidor.   |
+| Key   | Description             |
+|-------|-------------------------|
+| Enter | Start new pomodoro.     |
+| Space | Start a break.          |
+| R     | Resets the timer.       |
+| q     | Quit pomidor buffer.    |
+| Q     | Turns off pomidor.      |
+| h     | Put the session on hold |
+| H     | Resume on hold session  |
+
 
 ## Customization
 

--- a/pomidor.el
+++ b/pomidor.el
@@ -207,6 +207,9 @@ To disable sounds, set to nil."
 (defvar pomidor--current-history-session nil
   "Hold the current visible pomidor history snapshot.")
 
+(defvar pomidor--system-on-hold? nil
+  "Pomidor control of hold in system.")
+
 ;;; Private
 
 (defun pomidor--current-state ()
@@ -493,6 +496,8 @@ TIME may be nil."
     (define-key map (kbd "q") #'quit-window)
     (define-key map (kbd "Q") #'pomidor-quit)
     (define-key map (kbd "R") #'pomidor-reset)
+    (define-key map (kbd "h") #'pomidor-hold)
+    (define-key map (kbd "H") #'pomidor-unhold)
     (define-key map (kbd "RET") #'pomidor-stop)
     (define-key map (kbd "SPC") #'pomidor-break)
     (suppress-keymap map)
@@ -544,6 +549,22 @@ TIME may be nil."
   (let ((state (pomidor--current-state)))
     (plist-put state :stopped (current-time)))
   (nconc pomidor-global-state (list (pomidor--make-state))))
+
+(defun pomidor-hold ()
+  "Stop the current working pomidor and puts the system on hold."
+  (interactive)
+  (let ((state (pomidor--current-state)))
+    (plist-put state :stopped (current-time)))
+  (setq pomidor--system-on-hold? t)
+  (pomidor--cancel-timer))
+
+(defun pomidor-unhold ()
+  "Unhold and start a new pomidor."
+  (interactive)
+  (when pomidor--system-on-hold?
+    (nconc pomidor-global-state (list (pomidor--make-state)))
+    (setq pomidor--system-on-hold? nil)
+    (setq pomidor-timer (run-at-time nil 1 #'pomidor--update))))
 
 (defun pomidor-save-session ()
   "Save the current session in a file."

--- a/pomidor.el
+++ b/pomidor.el
@@ -207,7 +207,7 @@ To disable sounds, set to nil."
 (defvar pomidor--current-history-session nil
   "Hold the current visible pomidor history snapshot.")
 
-(defvar pomidor--system-on-hold? nil
+(defvar pomidor--system-on-hold-p nil
   "Pomidor control of hold in system.")
 
 ;;; Private
@@ -555,15 +555,15 @@ TIME may be nil."
   (interactive)
   (let ((state (pomidor--current-state)))
     (plist-put state :stopped (current-time)))
-  (setq pomidor--system-on-hold? t)
+  (setq pomidor--system-on-hold-p t)
   (pomidor--cancel-timer))
 
 (defun pomidor-unhold ()
   "Unhold and start a new pomidor."
   (interactive)
-  (when pomidor--system-on-hold?
+  (when pomidor--system-on-hold-p
     (nconc pomidor-global-state (list (pomidor--make-state)))
-    (setq pomidor--system-on-hold? nil)
+    (setq pomidor--system-on-hold-p nil)
     (setq pomidor-timer (run-at-time nil 1 #'pomidor--update))))
 
 (defun pomidor-save-session ()


### PR DESCRIPTION
Hi @TatriX 

While I am using pomidor, I have a period after lunch where I answer to emails, participate on meetings and whatnot, then I get back to coding and to my pomodor sessions. I got used to put the system on hold during this period and then re-start with a new session when I get back.

I was doing the obvious before, just start/stop two times the pomidor and get your two sessions separately.

I dont know if this is a desired feature to the package, if you fill fit would be welcome to include this too.

_EDIT: I had a conflict due to the previous PR. I fixed and submitted again._

Thanks!