### PR TITLE
add feature long breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.06 06/05/2020
+Add pomidor long breaks after `pomidor-breaks-before-long` with
+`pomidor-long-break-seconds` amount of time.
+
 ## v.05 04/05/2020
 Add `pomidor-hold` and `pomidor-unhold` functions to keep a period of
 time without working on your pomidor sessions and resume when needed.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ To change timer duration:
 
 ```
 
+To change behavior of long breaks:
+``` elisp
+(setq pomidor-breaks-before-long 4) ; wait 4 short breaks before long break
+(setq pomidor-long-break-seconds (* 20 60)) ; 20 minutes long break time
+```
+
 To disable or configure sounds:
 ```elisp
 (setq pomidor-sound-tick nil

--- a/pomidor.el
+++ b/pomidor.el
@@ -684,8 +684,8 @@ TIME may be nil."
   "A simple and cool pomodoro technique timer."
   (interactive)
   (switch-to-buffer (pomidor--get-buffer-create))
-  (setq pomidor--count-short-breaks 0)
   (unless (eq major-mode 'pomidor-mode)
+    (setq pomidor--count-short-breaks 0)
     (pomidor-mode))
   (pomidor--update))
 


### PR DESCRIPTION
Hello @TatriX and @mrbig033 , I finished a version of the long break feature and fix #32 . The current behavior is as follows:

1. If you start a work and then start the break a counter will increase +1
2. if you perform the 1) for `pomidor-breaks-before-long` times, the **next** break will take `pomidor-long-break-seconds `amount of time.
3. if you finished the long break either pressing `SPC` or `RET`, the counter will be reset to 0.
4. if you press `R` (reset) the counter will be reset to 0 too.
5. if you are in the long break session turn and got overwork, the message will tell  `Take a long break`.

Would love feedbacks and more testing. Also, can you provide some text to README @mrbig033?

Thanks!