### PR TITLE
using json-read-file

### DIFF
--- a/pomidor.el
+++ b/pomidor.el
@@ -29,6 +29,7 @@
 (require 'cl-lib)
 (require 'alert)
 (require 'dash)
+(require 'json)
 
 ;;; Customs
 (defgroup pomidor nil

--- a/pomidor.el
+++ b/pomidor.el
@@ -485,13 +485,9 @@ TIME may be nil."
 
 (defun pomidor--read-session (preserve-timestamp?)
   "Read the saved sessions."
-  (let* ((data (with-temp-buffer
-                 (insert-file-contents pomidor-save-session-file)
-                 (goto-char (point-min))
-                 (json-parse-buffer :object-type 'plist
-                                    :array-type 'list
-                                    :null-object nil)))
-         (data  (append data nil)))
+  (let* ((json-object-type 'plist)
+         (json-array-type 'list)
+         (data (json-read-file pomidor-save-session-file)))
     (if preserve-timestamp?
         data
       (-map (lambda (pomidor)


### PR DESCRIPTION
@TatriX I thought about the issue and `json-read-file` is also a builtin solution. I think will be simpler to just use it and let the `json-parse-buffer` out of business.

Fixes #42 