### PR TITLE
Fix snooze time formating error

### DIFF
--- a/pomidor.el
+++ b/pomidor.el
@@ -609,7 +609,7 @@ TIME may be nil."
                                  (list :started (funcall fmt-time (plist-get pomidor :started))
                                        :break (funcall fmt-time (plist-get pomidor :break))
                                        :stopped (funcall fmt-time (plist-get pomidor :stopped))
-                                       :snooze (funcall fmt-time (plist-get pomidor :snooze))
+                                       :snooze (plist-get pomidor :snooze)
                                        :session-ended (funcall fmt-time time-asked-to-save)))
                                pomidor-global-state))
            (new-history (append history-state global-state))

--- a/pomidor.el
+++ b/pomidor.el
@@ -29,6 +29,7 @@
 (require 'cl-lib)
 (require 'alert)
 (require 'dash)
+(require 'json)
 
 ;;; Customs
 (defgroup pomidor nil

--- a/pomidor.el
+++ b/pomidor.el
@@ -637,8 +637,8 @@ TIME may be nil."
               (pomidor--render
                (pomidor--get-history-buffer-create)
                (-filter (lambda (pomidor)
-                          (time-equal-p (car (last valid-session-dates))
-                                        (plist-get pomidor :session-ended)))
+                          (equal (car (last valid-session-dates))
+                                 (plist-get pomidor :session-ended)))
                         session-data)))
           (message "History is over, go forward."))))))
 
@@ -658,8 +658,8 @@ TIME may be nil."
               (pomidor--render
                (pomidor--get-history-buffer-create)
                (-filter (lambda (pomidor)
-                          (time-equal-p (car valid-session-dates)
-                                        (plist-get pomidor :session-ended)))
+                          (equal (car valid-session-dates)
+                                 (plist-get pomidor :session-ended)))
                         session-data)))
           (message "History is over, go backward."))))))
 

--- a/pomidor.el
+++ b/pomidor.el
@@ -485,13 +485,9 @@ TIME may be nil."
 
 (defun pomidor--read-session (preserve-timestamp?)
   "Read the saved sessions."
-  (let* ((data (with-temp-buffer
-                 (insert-file-contents pomidor-save-session-file)
-                 (goto-char (point-min))
-                 (json-parse-buffer :object-type 'plist
-                                    :array-type 'list
-                                    :null-object nil)))
-         (data  (append data nil)))
+  (let* ((json-object-type 'plist)
+         (json-array-type 'list)
+         (data (json-read-file pomidor-save-session-file)))
     (if preserve-timestamp?
         data
       (-map (lambda (pomidor)


### PR DESCRIPTION
This PR removes the formating time of the `:snooze` variable as it is a boolean. Fixes #44 