### PR TITLE
Load parse-time for using its function

### DIFF
--- a/pomidor.el
+++ b/pomidor.el
@@ -30,6 +30,7 @@
 (require 'alert)
 (require 'dash)
 (require 'json)
+(require 'parse-time)
 
 ;;; Customs
 (defgroup pomidor nil


### PR DESCRIPTION
This fixes the following byte-compile warning

```
In end of data:
pomidor.el:496:33: Warning: the function ‘parse-iso8601-time-string’ is not
    known to be defined.
```